### PR TITLE
[APS-19435] fix: bump commons-io 1.3.2 -> 2.18.0 (CVE-2021-29425)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ repositories { mavenCentral() }
 
 dependencies {
     implementation 'org.testng:testng:7.4.0'
-    implementation 'commons-io:commons-io:1.3.2'
+    implementation 'commons-io:commons-io:2.18.0'
     implementation 'org.seleniumhq.selenium:selenium-java:4.1.4'
     implementation 'com.browserstack:browserstack-local-java:1.0.6'
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'


### PR DESCRIPTION
## Security Fix: APS-19435

### Issue
`build.gradle:9` declared `commons-io:commons-io:1.3.2`, which carries CVE-2021-29425 (CWE-22, path traversal in `FilenameUtils.normalize` on commons-io < 2.7). Severity Low — the verifier flagged it as a **declared-only** dependency with no confirmed call sites.

### Root Cause
A very old (2008-era) commons-io 1.3.2 pinned on the compile classpath.

### Fix Applied
One-line bump:
```diff
- implementation 'commons-io:commons-io:1.3.2'
+ implementation 'commons-io:commons-io:2.18.0'
```
2.18.0 is a current stable 2.x (Maven Central latest is 2.22.0) and well past the patched 2.7. Verified the version exists on Maven Central (`commons-io-2.18.0.pom` -> HTTP 200).

### Reachability / safety
Independently confirmed there are **no** `commons-io` / `FilenameUtils` / `FileUtils` / `IOUtils` references anywhere under `src/` (only three test classes, none import commons-io). The dependency is declared-only, so the major-version bump is statically safe — no used API surface changes between 1.3.2 and 2.18.0 in this repo.

### Testing
- Maven Central version verification: PASS (2.18.0 resolves).
- Source-level reachability scan: PASS (zero call sites).
- **BLOCKED(no-gradle)**: this repo ships no Gradle wrapper (`gradlew`) and no system `gradle` is available in the environment, so `./gradlew dependencies --configuration compileClasspath` and the sample test could not be executed here. The change is statically safe per the above; recommend CI/maintainer run `./gradlew dependencies | grep commons-io` to confirm 2.18.0 resolves and no transitive re-introduces 1.3.2.

### Jira Ticket
https://browserstack.atlassian.net/browse/APS-19435

### Checklist
- [x] Security issue addressed (CVE-2021-29425 cleared)
- [x] Version verified on Maven Central
- [x] Declared-only / no call sites confirmed
- [ ] Gradle dependency resolution (BLOCKED — no gradle/gradlew in env)