### PR TITLE
Security: harden CI workflows + pin SDK (APS-19440 chain, 9 findings)

### DIFF
--- a/.github/workflows/maven-workflow-run.yml
+++ b/.github/workflows/maven-workflow-run.yml
@@ -10,6 +10,11 @@ on:
         description: 'The full commit id to build'
         required: true
 
+# Least-privilege default token. Only the check-status steps need checks: write.
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   comment-run:
     runs-on: ${{ matrix.os }}
@@ -20,12 +25,18 @@ jobs:
         java: [ '8', '11', '17' ]
         os: [ 'macos-latest', 'windows-latest', 'ubuntu-latest' ]
     name: Java-selenium Repo ${{ matrix.Java }} - ${{ matrix.os }} Sample
-    env:
-      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Validate commit_sha input
+        env:
+          COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
+        shell: bash
+        run: |
+          if [[ ! "$COMMIT_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::commit_sha must be a full 40-character hex commit id"
+            exit 1
+          fi
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: ${{ github.event.inputs.commit_sha }}
       - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975
@@ -48,19 +59,28 @@ jobs:
               console.log('Failed to create check run')
             }
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Run mvn test
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
         run: |
           mvn compile
           mvn test
       - name: Run mvn profile sample-local-test
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
         run: |
           mvn compile
           mvn test -P sample-local-test
       - name: Run mvn profile sample-test
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
         run: |
           mvn compile
           mvn test -P sample-test

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <surefire.version>2.19.1</surefire.version>
         <selenium.version>4.1.4</selenium.version>
         <json-simple.version>1.1.1</json-simple.version>
+        <browserstack-java-sdk.version>1.60.2</browserstack-java-sdk.version>
         <config.file>config/sample-local-test.testng.xml</config.file>
     </properties>
 
@@ -35,7 +36,7 @@
         <dependency>
             <groupId>com.browserstack</groupId>
             <artifactId>browserstack-java-sdk</artifactId>
-            <version>LATEST</version>
+            <version>${browserstack-java-sdk.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Hardens the GitHub Actions CI of this sample repo and pins the BrowserStack SDK to resolve a chain of 9 pentest findings (APS-19440 chain). Staging/Jenkins deploys are N/A — this repo only ships sample CI config. Local validation: workflow YAML lint (`yaml.safe_load`) + pom.xml XML validity check, both pass.

Ticket -> change:

- **APS-19440 (F-001)** — Pinned `actions/checkout@v3` and `actions/setup-java@v3` to full 40-char commit SHAs (kept `# v3` comments). The two `actions/github-script` steps and Semgrep.yml were already SHA-pinned.
- **APS-19444 (F-002)** — Pinned `browserstack-java-sdk` to exact version `1.60.2` (was `LATEST`) via a `browserstack-java-sdk.version` property in pom.xml. The `-javaagent` argLine resolves from this pinned dependency, so the agent is pinned too.
- **APS-19439 (F-003)** — Added an early "Validate commit_sha input" step that fails the job unless the input matches `^[0-9a-fA-F]{40}$`, so the value reaching `actions/checkout` `ref:` is constrained. `commit_sha` is never interpolated directly into a `run:` shell line (passed via `env:` and the validation reads `"$COMMIT_SHA"`).
- **APS-19446 (F-004)** — The same 40-hex validation runs before the `checks.create` steps, so an attacker can no longer set `head_sha` to an arbitrary value to spoof check status. `commit_sha` continues to be passed to github-script via `env:` (no shell interpolation).
- **APS-19438 (F-005)** — Moved `BROWSERSTACK_USERNAME` / `BROWSERSTACK_ACCESS_KEY` off the job-level `env:` and down to only the three `mvn test` steps that need them, so they no longer leak into checkout / setup-java / github-script steps.
- **APS-19434 (C-001)** — workflow_dispatch `commit_sha` RCE collapses: input is validated (F-003), not shell-interpolated, and actions are SHA-pinned (F-001).
- **APS-19442 (C-002)** — javaagent secret-exfil collapses: SDK/javaagent pinned to exact `1.60.2` (F-002).
- **APS-19433 (C-003)** — Mutable `actions/checkout@v3` substitution collapses: now SHA-pinned (F-001).
- **APS-19441 (C-004)** — Commit-status spoofing + write-default token bypass collapses: `head_sha` validated (F-004) and added a least-privilege top-level `permissions:` block (`contents: read`; `checks: write` only because the job genuinely creates check runs).
